### PR TITLE
Add interactive onboarding tour

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,33 @@
+# Guia de Onboarding
+
+Bem-vindo ao **FinançasPessoais**! Este breve guia apresenta as principais funcionalidades e ensina como iniciar o projeto localmente.
+
+## Primeiros passos
+
+1. Certifique-se de ter **Node.js** instalado (recomendado v18 ou superior).
+2. Clone o repositório e instale as dependências:
+   ```bash
+   npm install
+   ```
+3. Inicie o ambiente de desenvolvimento:
+   ```bash
+   npm run dev
+   ```
+4. Acesse `http://localhost:3000` no navegador para visualizar o painel inicial.
+
+## Principais funcionalidades
+
+- **Dashboard** – visão geral de receitas, despesas e saldo. Acompanhe rapidamente sua taxa de economia e categorias de gasto mais relevantes.
+- **Transações** – registre entradas e saídas, categorizando cada movimentação financeira. Permite editar ou remover lançamentos.
+- **Orçamentos** – defina limites mensais por categoria e acompanhe o quanto já foi utilizado.
+- **Relatórios** – visualize gráficos e resumos para entender melhor sua vida financeira ao longo do tempo.
+
+A navegação entre as páginas está acessível pelo menu superior da aplicação.
+
+## Próximos passos
+
+Explore cada seção para inserir transações de exemplo e configurar orçamentos. Use os relatórios para identificar tendências de gastos e oportunidades de economia.
+
+Em caso de dúvidas ou problemas, abra uma *issue* no repositório.
+
+Bom uso!

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # finance-app
+
+Este repositório contém o **FinançasPessoais**, uma aplicação web para controle de finanças.
+
+Consulte o arquivo [ONBOARDING.md](ONBOARDING.md) para um passo a passo de instalação e uso das principais funcionalidades.
+
+Ao acessar a aplicação pela primeira vez, será exibido um tour guiado apresentando cada área do sistema.

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,12 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+.onboarding-highlight {
+  @apply ring-4 ring-blue-500/50 rounded-md;
+  position: relative;
+  z-index: 50;
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import OnboardingTour from '@/components/onboarding-tour'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +15,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <OnboardingTour />
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,16 +71,16 @@ export default async function Home() {
             <span>FinançasPessoais</span>
           </Link>
           <nav className="ml-auto flex gap-2">
-            <Button asChild variant="outline" size="sm">
+            <Button asChild variant="outline" size="sm" id="nav-transactions">
               <Link href="/transactions">Transações</Link>
             </Button>
-            <Button asChild variant="outline" size="sm">
+            <Button asChild variant="outline" size="sm" id="nav-budgets">
               <Link href="/budgets">Orçamentos</Link>
             </Button>
-            <Button asChild variant="outline" size="sm">
+            <Button asChild variant="outline" size="sm" id="nav-reports">
               <Link href="/reports">Relatórios</Link>
             </Button>
-            <Button asChild size="sm">
+            <Button asChild size="sm" id="nav-new-transaction">
               <Link href="/transactions/new">
                 <Plus className="mr-2 h-4 w-4" />
                 Nova Transação
@@ -89,7 +89,7 @@ export default async function Home() {
           </nav>
         </header>
         <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div id="dashboard-cards" className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Saldo Total</CardTitle>

--- a/components/onboarding-tour.tsx
+++ b/components/onboarding-tour.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+
+const steps = [
+  {
+    selector: "#dashboard-cards",
+    text: "Aqui você acompanha seu saldo e estatísticas gerais.",
+  },
+  {
+    selector: "#nav-transactions",
+    text: "Acesse todas as suas transações por aqui.",
+  },
+  {
+    selector: "#nav-budgets",
+    text: "Gerencie seus orçamentos nesta seção.",
+  },
+  {
+    selector: "#nav-reports",
+    text: "Veja relatórios e gráficos financeiros.",
+  },
+  {
+    selector: "#nav-new-transaction",
+    text: "Registre rapidamente uma nova transação.",
+  },
+]
+
+export default function OnboardingTour() {
+  const [step, setStep] = useState(0)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const done = localStorage.getItem("onboardingComplete")
+    if (!done) {
+      setOpen(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const current = steps[step]
+    if (!current) return
+    const el = document.querySelector(current.selector) as HTMLElement | null
+    if (el) {
+      el.classList.add("onboarding-highlight")
+      el.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+    return () => {
+      if (el) el.classList.remove("onboarding-highlight")
+    }
+  }, [step, open])
+
+  function next() {
+    if (step < steps.length - 1) {
+      setStep((s) => s + 1)
+    } else {
+      if (typeof window !== "undefined") {
+        localStorage.setItem("onboardingComplete", "true")
+      }
+      setOpen(false)
+    }
+  }
+
+  if (!open) return null
+
+  const current = steps[step]
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-end sm:items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded-md shadow-lg max-w-sm mx-2">
+        <p className="mb-4">{current.text}</p>
+        <div className="text-right">
+          <Button onClick={next} size="sm">
+            {step < steps.length - 1 ? "Próximo" : "Finalizar"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create a client component that guides new users through the interface
- highlight nav buttons and dashboard cards on first visit
- style highlight class in global CSS
- include `OnboardingTour` in layout
- document the new tour in README

## Testing
- `npx next lint` *(fails: missing Next.js peer deps)*
- `npm install --force` *(succeeds with warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6846d3928ce0832b8bb385f5e189ba34