### PR TITLE
Add env example and README install steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Environment variables for finance-app
+# Replace placeholder values with your actual credentials
+KV_REST_API_URL=
+KV_REST_API_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # finance-app
+
+## Installation
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Copy `.env.example` to `.env` and fill in the variables.
+
+3. Start the development server:
+
+```bash
+npm run dev
+```
+
+Or build for production:
+
+```bash
+npm run build
+```


### PR DESCRIPTION
## Summary
- create `.env.example` with expected variables
- update `.gitignore` to allow `.env.example`
- expand installation instructions in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_b_6846d204bcc0832bb30e6a1c8fee98be