### PR TITLE
Fix delete button UI update

### DIFF
--- a/components/delete-budget-button.tsx
+++ b/components/delete-budget-button.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { Trash } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { removeBudget } from "@/app/actions"
@@ -11,11 +12,13 @@ interface DeleteBudgetButtonProps {
 
 export function DeleteBudgetButton({ id }: DeleteBudgetButtonProps) {
   const [isDeleting, setIsDeleting] = useState(false)
+  const router = useRouter()
 
   const handleDelete = async () => {
     setIsDeleting(true)
     try {
       await removeBudget(id)
+      router.refresh()
     } catch (error) {
       console.error("Erro ao excluir orçamento:", error)
     } finally {

--- a/components/delete-transaction-button.tsx
+++ b/components/delete-transaction-button.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { Trash } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { removeTransaction } from "@/app/actions"
@@ -11,11 +12,13 @@ interface DeleteTransactionButtonProps {
 
 export function DeleteTransactionButton({ id }: DeleteTransactionButtonProps) {
   const [isDeleting, setIsDeleting] = useState(false)
+  const router = useRouter()
 
   const handleDelete = async () => {
     setIsDeleting(true)
     try {
       await removeTransaction(id)
+      router.refresh()
     } catch (error) {
       console.error("Erro ao excluir transação:", error)
     } finally {


### PR DESCRIPTION
## Summary
- refresh data on budget/transaction delete

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6845a7324938832ba0ec59bffb74ef88