### PR TITLE
Add CSV export routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # finance-app
+
+A simple finance management application built with Next.js and Redis.
+
+## Features
+
+- Manage transactions and budgets
+- Export transactions and budgets as CSV using `/api/export/transactions` and `/api/export/budgets`

--- a/app/api/export/budgets/route.ts
+++ b/app/api/export/budgets/route.ts
@@ -1,0 +1,18 @@
+import { getAllBudgets } from "@/lib/redis";
+
+export async function GET() {
+  const budgets = await getAllBudgets();
+  const header = ["id", "category", "limit", "spent", "period"];
+  const rows = budgets.map((b) =>
+    [b.id, b.category.replace(/"/g, '""'), b.limit, b.spent, b.period]
+      .map((field) => `"${field}"`)
+      .join(",")
+  );
+  const csv = [header.join(","), ...rows].join("\n");
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": "attachment; filename=budgets.csv",
+    },
+  });
+}

--- a/app/api/export/transactions/route.ts
+++ b/app/api/export/transactions/route.ts
@@ -1,0 +1,32 @@
+import { getAllTransactions } from "@/lib/redis";
+
+export async function GET() {
+  const transactions = await getAllTransactions();
+  const header = [
+    "id",
+    "description",
+    "amount",
+    "type",
+    "category",
+    "date",
+    "notes",
+  ];
+  const rows = transactions.map((t) =>
+    [
+      t.id,
+      t.description.replace(/"/g, '""'),
+      t.amount,
+      t.type,
+      t.category,
+      t.date,
+      t.notes ? t.notes.replace(/"/g, '""') : "",
+    ].map((field) => `"${field}"`).join(",")
+  );
+  const csv = [header.join(","), ...rows].join("\n");
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": "attachment; filename=transactions.csv",
+    },
+  });
+}

--- a/app/budgets/page.tsx
+++ b/app/budgets/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { Edit, Plus } from "lucide-react"
+import { Edit, Plus, Download } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -31,6 +31,12 @@ export default async function BudgetsPage() {
           </Button>
           <Button asChild variant="outline" size="sm">
             <Link href="/reports">Relatórios</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/api/export/budgets">
+              <Download className="mr-2 h-4 w-4" />
+              Exportar CSV
+            </Link>
           </Button>
           <Button asChild size="sm">
             <Link href="/budgets/new">

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { ArrowUpDown, ChevronDown, Filter, Plus } from "lucide-react"
+import { ArrowUpDown, ChevronDown, Filter, Plus, Download } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -32,6 +32,12 @@ export default async function TransactionsPage() {
           </Button>
           <Button asChild variant="outline" size="sm">
             <Link href="/reports">Relatórios</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/api/export/transactions">
+              <Download className="mr-2 h-4 w-4" />
+              Exportar CSV
+            </Link>
           </Button>
           <Button asChild size="sm">
             <Link href="/transactions/new">


### PR DESCRIPTION
## Summary
- add API routes for exporting transactions and budgets in CSV format
- add export CSV buttons in Transactions and Budgets pages
- document new feature in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845c4ed0434832ba5ef75f95bf2a4c4